### PR TITLE
Add coloring by prefix using conf:byPrefix.

### DIFF
--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -43,6 +43,10 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	private String authPassword = null;
 	private String defaultInverseBehaviour = "collapse";
 
+	public enum ColorStrategy {RANDOM, CLASS, PREFIX}
+	private ColorStrategy colorStrategy =  ColorStrategy.RANDOM;
+	public ColorStrategy getColorStrategy() {return colorStrategy;}
+
 	private List<String> defaultQueries = null, defaultRawDataQueries = null, defaultInversesQueries = null, defaultInversesTest = null, defaultInversesCountQueries = null, typeProperties = null, audioProperties = null, imageProperties = null, videoProperties = null, linkingProperties = null, titleProperties = null, descriptionProperties = null, longitudeProperties = null, latitudeProperties = null;
 	private List<String> colorPair = null, skipDomains = null, mainOntologiesPrefixes = null;
 	private Map<String, String> colorPairMatcher = null;
@@ -111,10 +115,16 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 
 		colorPair = getMultiConfValue("colorPair");
 
-		if (colorPair != null && colorPair.size() == 1 && colorPair.get(0).startsWith("http://")) {
+		if (colorPair != null && colorPair.size() == 1 && colorPair.get(0).startsWith("http://"))
+		{
+			switch(colorPair.get(0).replace("http://lodview.it/conf#", ""))
+			{
+			case "byClass": colorStrategy= ColorStrategy.CLASS; break;
+			case "byPrefix": colorStrategy= ColorStrategy.PREFIX; break;
+			}
 			colorPairMatcher = populateColorPairMatcher();
 		}
-
+				
 		skipDomains = getMultiConfValue("skipDomains");
 	}
 
@@ -280,6 +290,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	}
 
 	public String getRandomColorPair() {
+		if(colorStrategy!=ColorStrategy.RANDOM) {return "#914848-#7d3e3e";}
 		int randomNum = rand.nextInt(colorPair.size());
 		return colorPair.get(randomNum);
 	}

--- a/src/main/java/org/dvcama/lodview/utils/Misc.java
+++ b/src/main/java/org/dvcama/lodview/utils/Misc.java
@@ -11,6 +11,7 @@ import org.dvcama.lodview.bean.PropertyBean;
 import org.dvcama.lodview.bean.ResultBean;
 import org.dvcama.lodview.bean.TripleBean;
 import org.dvcama.lodview.conf.ConfigurationBean;
+import org.dvcama.lodview.conf.ConfigurationBean.ColorStrategy;
 
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.NodeIterator;
@@ -47,23 +48,30 @@ public class Misc {
 	}
 
 	public static String guessColor(String colorPair, ResultBean r, ConfigurationBean conf) {
-
-		if (conf.getColorPairMatcher() != null && conf.getColorPairMatcher().size() > 0) {
+		switch(conf.getColorStrategy())
+		{
+		case CLASS: {
 			try {
 				List<TripleBean> m = r.getResources(r.getMainIRI()).get(r.getTypeProperty());
-				for (String key : conf.getColorPairMatcher().keySet()) {
-					for (TripleBean tripleBean : m) {
-						if (tripleBean.getValue().equals(key)) {
-							colorPair = conf.getColorPairMatcher().get(key);
-							return colorPair;
-						}
-					}
+				for (TripleBean tripleBean : m)
+				{
+					colorPair = conf.getColorPairMatcher().get(tripleBean.getValue());			
+					if(colorPair!=null) return colorPair;
 				}
 			} catch (Exception e) {
 			}
-			return conf.getColorPairMatcher().get("http://lodview.it/conf#otherClasses");
+			return conf.getColorPairMatcher().get("http://lodview.it/conf#otherClasses");			
 		}
-
+		case PREFIX: {
+			for (String prefix : conf.getColorPairMatcher().keySet()) {
+				if(r.getMainIRI().startsWith(prefix))
+				{
+					return conf.getColorPairMatcher().get(prefix);
+				}
+			}
+		}
+		default: break;
+		}
 		return colorPair;
 	}
 


### PR DESCRIPTION
Added the conf:byPrefix option that colors resources by prefix.
Otherwise, it works the same way as conf:byClass.
Incidentally made the coloring behaviour a bit more explicit through the colorStrategy enum.
Also fixed the color of the starting page and resources without stated prefixes to a specific constant, which is in my opinion better then before (was black and white).
But this could still be improved, for example with a "default" or "fallback" color value in the config.
Please test before merge, I use it on a different knowledge base.