### PR TITLE
Support environment variables with the 'LodLive' prefix to override single config values in conf.ttl.

### DIFF
--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -82,12 +82,12 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 		httpRedirectExcludeList = getSingleConfValue("httpRedirectExcludeList", "");
 
 		publicUrlPrefix = getSingleConfValue("publicUrlPrefix", "");
-		publicUrlPrefix = publicUrlPrefix.replaceAll(".+/auto$", context.getContextPath() + "/");
+		publicUrlPrefix = publicUrlPrefix.replaceAll("^(.+/)?auto$", context.getContextPath() + "/");
 
 		contentEncoding = getSingleConfValue("contentEncoding");
 		staticResourceURL = getSingleConfValue("staticResourceURL", "");
 		homeUrl = getSingleConfValue("homeUrl", "/");
-		staticResourceURL = staticResourceURL.replaceAll(".+/auto$", context.getContextPath() + "/staticResources/");
+		staticResourceURL = staticResourceURL.replaceAll("^(.+/)?auto$", context.getContextPath() + "/staticResources/");
 
 		preferredLanguage = getSingleConfValue("preferredLanguage");
 
@@ -148,6 +148,8 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	}
 
 	private String getSingleConfValue(String prop, String defaultValue) {
+		String value = System.getenv("LodView"+prop);
+		if(value!=null) {return value;}
 		NodeIterator iter = confModel.listObjectsOfProperty(confModel.createProperty(confModel.getNsPrefixURI("conf"), prop));
 		while (iter.hasNext()) {
 			RDFNode node = iter.next();


### PR DESCRIPTION
See #46. This is the minimal pull request that only supports environment variables but not .env files.

To test it create the following `.env` file:

```
LodViewIRInamespace=http://dbpedia.org/resource/
LodViewendpoint=https://dbpedia.org/sparql
LodViewendpointType=virtuoso
LodViewhttpRedirectSuffix=
LodViewredirectionStrategy=
LodViewcontentEncoding=UTF-8
LodViewauthUsername=
LodViewauthPassword=
LodViewdefaultInverseBehaviour=open
LodViewpublicUrlPrefix=auto
LodViewforceIriEncoding=auto
LodViewhomeUrl=http://dbpedia.org/resource/Leipzig
LodViewstaticResourceURL=auto
LodViewpreferredLanguage=auto
LodViewlicense="This is a test license"
LodViewlast=.
```

and then execute in bash:

```bash
set -o allexport
source .env
set +o allexport
```
And then `mvn jetty:run`.

However this will not be much different than the default configuration, so you can also try another one:

```
LodViewIRInamespace=http://hitontology.eu/ontology/
LodViewendpoint=https://hitontology.eu/sparql
LodViewendpointType=virtuoso
LodViewhttpRedirectSuffix=
LodViewredirectionStrategy=
LodViewcontentEncoding=UTF-8
LodViewauthUsername=
LodViewauthPassword=
LodViewdefaultInverseBehaviour=open
LodViewpublicUrlPrefix=auto
LodViewforceIriEncoding=auto
LodViewhomeUrl=http://hitontology.eu/ontology/SoftwareProduct
LodViewstaticResourceURL=auto
LodViewpreferredLanguage=auto
LodViewlicense="Test License"
LodViewlast=.
```

I am not a developer of that code base so I hope somebody can check if I did it correctly or if there is a more elegant solution possible.