### PR TITLE
Support .env file for configuration in addition to environment variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<description>lodview</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java-version>1.7</java-version>
+		<java-version>1.8</java-version>
 		<org.springframework-version>4.2.4.RELEASE</org.springframework-version>
 		<org.aspectj-version>1.8.1</org.aspectj-version>
 		<org.slf4j-version>1.6.1</org.slf4j-version>
@@ -105,7 +105,11 @@
 			<artifactId>spring-boot-starter-integration</artifactId>
 			<version>1.1.4.RELEASE</version>
 		</dependency>
-
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>dotenv-java</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -82,12 +82,12 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 		httpRedirectExcludeList = getSingleConfValue("httpRedirectExcludeList", "");
 
 		publicUrlPrefix = getSingleConfValue("publicUrlPrefix", "");
-		publicUrlPrefix = publicUrlPrefix.replaceAll(".+/auto$", context.getContextPath() + "/");
+		publicUrlPrefix = publicUrlPrefix.replaceAll("^(.+/)?auto$", context.getContextPath() + "/");
 
 		contentEncoding = getSingleConfValue("contentEncoding");
 		staticResourceURL = getSingleConfValue("staticResourceURL", "");
 		homeUrl = getSingleConfValue("homeUrl", "/");
-		staticResourceURL = staticResourceURL.replaceAll(".+/auto$", context.getContextPath() + "/staticResources/");
+		staticResourceURL = staticResourceURL.replaceAll("^(.+/)?auto$", context.getContextPath() + "/staticResources/");
 
 		preferredLanguage = getSingleConfValue("preferredLanguage");
 
@@ -148,6 +148,8 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	}
 
 	private String getSingleConfValue(String prop, String defaultValue) {
+		String value = System.getenv("LodView"+prop);
+		if(value!=null) {return value;}
 		NodeIterator iter = confModel.listObjectsOfProperty(confModel.createProperty(confModel.getNsPrefixURI("conf"), prop));
 		while (iter.hasNext()) {
 			RDFNode node = iter.next();

--- a/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
+++ b/src/main/java/org/dvcama/lodview/conf/ConfigurationBean.java
@@ -18,6 +18,7 @@ import com.hp.hpl.jena.rdf.model.NodeIterator;
 import com.hp.hpl.jena.rdf.model.RDFNode;
 import com.hp.hpl.jena.rdf.model.ResIterator;
 import com.hp.hpl.jena.rdf.model.Resource;
+import io.github.cdimascio.dotenv.Dotenv;
 
 public class ConfigurationBean implements ServletContextAware, Cloneable {
 
@@ -52,6 +53,8 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	private Map<String, String> colorPairMatcher = null;
 
 	Random rand = new Random();
+	
+	private Dotenv dotenv = Dotenv.load();
 
 	public ConfigurationBean() throws IOException, Exception {
 
@@ -148,7 +151,7 @@ public class ConfigurationBean implements ServletContextAware, Cloneable {
 	}
 
 	private String getSingleConfValue(String prop, String defaultValue) {
-		String value = System.getenv("LodView"+prop);
+		String value = dotenv.get("LodView"+prop);
 		if(value!=null) {return value;}
 		NodeIterator iter = confModel.listObjectsOfProperty(confModel.createProperty(confModel.getNsPrefixURI("conf"), prop));
 		while (iter.hasNext()) {


### PR DESCRIPTION
This expands https://github.com/LodLive/LodView/pull/47 with support for .env files but it requires another Maven dependency and a Java version upgrade to version 8.

If you do not want to do that, please consider https://github.com/LodLive/LodView/pull/47 instead.

See #46.

I'm not a developer of this codebase so please check this for side effects.

This feature should be very helpful when deploying containers such as docker.