### PR TITLE
Upgrade Tomcat from version 7 to 9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . /app
 RUN mvn compile war:war
 
-FROM tomcat:7
+FROM tomcat:9
 LABEL maintainer=adrian.gschwend@zazuko.com
 COPY --from=builder /app/target/lodview.war /usr/local/tomcat/webapps/lodview.war
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
According to https://tomcat.apache.org/whichversion.html, Tomcat version 7 has the status of "archived" and they suggest upgrading:

> Please note that although we offer downloads and documentation of older releases, such as Apache Tomcat 7.x, we strongly encourage users to use the latest stable version of Apache Tomcat whenever possible

However version 10 did not work in testing, even version 10.0 that should work with Java version 8, so I only upgraded to version 9, which worked in manual local testing:

```bash
$ docker build -t lodview .
$ docker run -p 8080:8080 lodview
$ firefox "http://localhost:8080/lodview/Leipzig"
```