### PR TITLE
Use serial garbage collector to reduce memory consumption.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mvn compile war:war
 
 FROM tomcat:7
 LABEL maintainer=adrian.gschwend@zazuko.com
+ENV CATALINA_OPTS="-XX:+UseSerialGC"
 COPY --from=builder /app/target/lodview.war /usr/local/tomcat/webapps/lodview.war
 CMD ["catalina.sh", "run"]
 EXPOSE 8080 8009


### PR DESCRIPTION
Memory consumption of the default and serial garbage collectors are compared in https://github.com/LodLive/LodView/issues/54.