### PR TITLE
Use Docker layer cache for Maven dependencies to speed up repeated builds with the same pom.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM maven:3-jdk-8 AS builder
 WORKDIR /app
+COPY pom.xml /app
+RUN mvn dependency:resolve -Dmaven.test.skip=true
 COPY . /app
 RUN mvn compile war:war
 


### PR DESCRIPTION
On an Intel i7-9700, this reduces repeated `docker build` time with equal pom.xml but other changes from 14.4s to 5.6s.