### PR TITLE
fix conf:homeUrl default value

### DIFF
--- a/src/main/webapp/WEB-INF/conf.ttl
+++ b/src/main/webapp/WEB-INF/conf.ttl
@@ -153,7 +153,7 @@
 
 ##	home link (accessible from the banner)
 
-	conf:homeUrl <http://remember to change this in conf.ttl>;
+	conf:homeUrl <http://remember-to-change-this-in-conf.ttl>;
 
   	
 ##	static resources publishing point, "staticResources/" is needed if you are going 


### PR DESCRIPTION
Docker builds typically overwrite this value using the environment variable LodViewhomeUrl, however the spaces in the URL break the build in that case.